### PR TITLE
CQ-6820. Fix the AwsTag key.

### DIFF
--- a/clumioapi/models/aws_tag.py
+++ b/clumioapi/models/aws_tag.py
@@ -109,10 +109,10 @@ class AwsTag:
         key = dictionary.get('key')
         key_id = dictionary.get('key_id')
         organizational_unit_id = dictionary.get('organizational_unit_id')
-        key = 'protection_info'
+        p_key = 'protection_info'
         p_protection_info = (
-            protection_info.ProtectionInfo.from_dictionary(dictionary.get(key))
-            if dictionary.get(key)
+            protection_info.ProtectionInfo.from_dictionary(dictionary.get(p_key))
+            if dictionary.get(p_key)
             else None
         )
 


### PR DESCRIPTION
The value of the key was accidentally hard-coded to 'protection_info'