### PR TITLE
CQ-7025:Simply errors handling in ClumioException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.16.6
+Fix error message handling while raising ClumioException
+
 ## 0.16.5
 Added another missing PG model.
 

--- a/clumioapi/__init__.py
+++ b/clumioapi/__init__.py
@@ -2,7 +2,7 @@
 # Copyright 2025. Clumio, Inc.
 #
 
-sdk_version = '0.16.5'
+sdk_version = '0.16.6'
 
 __all__ = [
     'api_helper',

--- a/clumioapi/exceptions/clumio_exception.py
+++ b/clumioapi/exceptions/clumio_exception.py
@@ -2,10 +2,7 @@
 # Copyright 2023. Clumio, Inc.
 #
 
-from typing import Any, List, Mapping, Optional
-
-from clumioapi import api_helper
-from clumioapi.models import single_error_response
+from typing import Any
 
 
 class ClumioException(Exception):
@@ -22,30 +19,11 @@ class ClumioException(Exception):
         Args:
             reason: The reason (or error message) for the Exception
                 to be raised.
-            context:  The HttpContext of the API call.
+            errors:  Errors.
         """
-        self.errors: List[single_error_response.SingleErrorResponse] = list()
-        dictionary = api_helper.json_deserialize(errors)
-        if isinstance(dictionary, dict):
-            self.unbox(dictionary)
-        if len(self.errors) > 0:
-            error_msgs: List[str] = [
-                f'{str(i+1)}. {self.errors[i].error_message}\n' for i in range(len(self.errors))
-            ]
-            errors_string = ''.join(error_msgs)
-            reason = f'{reason}\n{errors_string}'
-        super().__init__(reason)
-
-    def unbox(self, dictionary: Optional[Mapping[str, Any]]) -> None:
-        """Populates the object properties by extracting them from dictionary.
-
-        Args:
-            dictionary: A dictionary representation of the object as obtained
-                from the deserialization of the server's response. The keys MUST
-                match property names in the API description.
-        """
-        if dictionary.get('errors'):
-            for structure in dictionary.get('errors', {}):
-                self.errors.append(
-                    single_error_response.SingleErrorResponse.from_dictionary(structure)
-                )
+        
+        if errors is not None:
+            errors_str = json.dumps(errors, indent=2, default=str)
+        else:
+            errors_str = "None"
+        super().__init__(f'ClumioException: {reason}, errors: {errors_str}')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setup(
     name='clumioapi',
-    version='0.16.5',
+    version='0.16.6',
     description='Python SDK for Clumio REST API',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mbuddharaju/.pyenv/versions/3.12.10/lib/python3.12/site-packages/clumioapi/controllers/aws_ebs_volumes_v1.py", line 187, in list_aws_ebs_volumes
    raise clumio_exception.ClumioException(
clumioapi.exceptions.clumio_exception.ClumioException: ClumioException: Error occurred while executing list_aws_ebs_volumes., errors: {'errors': [{'error_code': 215, 'error_message': 'A resource with the requested ID could not be found.'}]}

wiith this change it throws exception as above.

Previously  we were getting TypeError